### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/sphinxcontrib/requirements.txt
+++ b/sphinxcontrib/requirements.txt
@@ -1,7 +1,7 @@
 ansi2html==1.7.0
 beautifulsoup4==4.11.1
 colorama==0.4.4
-css_inline==0.8.6
+css_inline==0.10.1
 docutils==0.17.1
 mezmorize==0.28.2
 pexpect==4.8.0


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version